### PR TITLE
Add fuel tank upgrades

### DIFF
--- a/Entities/Store/SpacePortStore.tres
+++ b/Entities/Store/SpacePortStore.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="StoreData" load_steps=9 format=3 uid="uid://lltn0cexcj8y"]
+[gd_resource type="Resource" script_class="StoreData" load_steps=12 format=3 uid="uid://lltn0cexcj8y"]
 
 [ext_resource type="Script" uid="uid://by2u1e45ryfos" path="res://entities/Store/StoreData.gd" id="1"]
 [ext_resource type="Resource" uid="uid://c8l4yamtxt5b5" path="res://entities/Upgrades/items/Hull_1.tres" id="2"]
@@ -8,8 +8,11 @@
 [ext_resource type="Resource" uid="uid://cargo1upgrade" path="res://entities/Upgrades/items/Cargo_1.tres" id="5"]
 [ext_resource type="Resource" uid="uid://cargo2upgrade" path="res://entities/Upgrades/items/Cargo_2.tres" id="6"]
 [ext_resource type="Resource" uid="uid://cargo3upgrade" path="res://entities/Upgrades/items/Cargo_3.tres" id="7"]
+[ext_resource type="Resource" uid="uid://fueltank1upgrade" path="res://entities/Upgrades/items/FuelTank_1.tres" id="8"]
+[ext_resource type="Resource" uid="uid://fueltank2upgrade" path="res://entities/Upgrades/items/FuelTank_2.tres" id="9"]
+[ext_resource type="Resource" uid="uid://fueltank3upgrade" path="res://entities/Upgrades/items/FuelTank_3.tres" id="10"]
 
 [resource]
 script = ExtResource("1")
 store_name = "Space Port Store"
-upgrades = Array[ExtResource("2_47uo8")]([ExtResource("2"), ExtResource("3"), ExtResource("4"), ExtResource("5"), ExtResource("6"), ExtResource("7")])
+upgrades = Array[ExtResource("2_47uo8")]([ExtResource("2"), ExtResource("3"), ExtResource("4"), ExtResource("5"), ExtResource("6"), ExtResource("7"), ExtResource("8"), ExtResource("9"), ExtResource("10")])

--- a/Entities/Upgrades/items/FuelTank_1.tres
+++ b/Entities/Upgrades/items/FuelTank_1.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="UpgradeItem" load_steps=2 format=3 uid="uid://fueltank1upgrade"]
+
+[ext_resource type="Script" path="res://entities/Upgrades/UpgradeItem.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+upgrade_id = "fuel_tank_1"
+display_name = "Fuel Tank I"
+description = "Expanded fuel storage. Adds 25 points to maximum fuel capacity."
+upgrade_path = "fuel_tank"
+cost = 40
+effect_target = "max_fuel"
+effect_value = 25.0

--- a/Entities/Upgrades/items/FuelTank_2.tres
+++ b/Entities/Upgrades/items/FuelTank_2.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="UpgradeItem" load_steps=2 format=3 uid="uid://fueltank2upgrade"]
+
+[ext_resource type="Script" path="res://entities/Upgrades/UpgradeItem.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+upgrade_id = "fuel_tank_2"
+display_name = "Fuel Tank II"
+description = "Enhanced fuel storage. Adds 25 points to maximum fuel capacity."
+upgrade_path = "fuel_tank"
+tier = 2
+cost = 80
+effect_target = "max_fuel"
+effect_value = 25.0

--- a/Entities/Upgrades/items/FuelTank_3.tres
+++ b/Entities/Upgrades/items/FuelTank_3.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="UpgradeItem" load_steps=2 format=3 uid="uid://fueltank3upgrade"]
+
+[ext_resource type="Script" path="res://entities/Upgrades/UpgradeItem.gd" id="1"]
+
+[resource]
+script = ExtResource("1")
+upgrade_id = "fuel_tank_3"
+display_name = "Fuel Tank III"
+description = "Maximum fuel storage. Adds 50 points to maximum fuel capacity."
+upgrade_path = "fuel_tank"
+tier = 3
+cost = 160
+effect_target = "max_fuel"
+effect_value = 50.0


### PR DESCRIPTION
## Summary
- Add three tiers of fuel tank upgrades that increase max fuel capacity
- Fuel Tank I: +25 max_fuel (40 credits)
- Fuel Tank II: +25 max_fuel (80 credits)  
- Fuel Tank III: +50 max_fuel (160 credits)
- Upgrades are available at the Space Port store

Closes #18

## Test plan
- [ ] Open the game and visit the Space Port store
- [ ] Verify all three fuel tank upgrades appear in the store
- [ ] Purchase Fuel Tank I and confirm max fuel increases from 100 to 125
- [ ] Verify tier progression works (can't buy Tier 2 without Tier 1)
- [ ] Save and reload to confirm upgrades persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)